### PR TITLE
Add the ability to show the current line number in presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ require("presence"):setup({
     plugin_manager_text = "Managing plugins"          -- Format string rendered when managing plugins
     reading_text        = "Reading %s"                -- Format string rendered when a read-only or unmodifiable file is loaded in the buffer
     workspace_text      = "Working on %s",            -- Workspace format string (either string or function(git_project_name: string|nil, buffer: string): string)
-	line_number_text    = "Line %s out of %s",        -- Line number format string (for when enable_line_number is set to true)
+    line_number_text    = "Line %s out of %s",        -- Line number format string (for when enable_line_number is set to true)
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ let g:presence_main_image          = "neovim"
 let g:presence_client_id           = "793271441293967371"
 let g:presence_log_level
 let g:presence_debounce_timeout    = 10
-let g:presence_enable_line_number  = false
+let g:presence_enable_line_number  = 0
 
 " Rich Presence text options
 let g:presence_editing_text        = "Editing %s"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ require("presence"):setup({
     main_image          = "neovim",                   -- Main image display (either "neovim" or "file")
     client_id           = "793271441293967371",       -- Use your own Discord application client id (not recommended)
     log_level           = nil,                        -- Log messages at or above this level (one of the following: "debug", "info", "warn", "error")
-    debounce_timeout    = 15,                         -- Number of seconds to debounce TextChanged events (or calls to `:lua package.loaded.presence:update(<filename>, true)`)
+    debounce_timeout    = 10,                         -- Number of seconds to debounce events (or calls to `:lua package.loaded.presence:update(<filename>, true)`)
+    enable_line_number  = false,                      -- Displays the current line number instead of the current project
 
     -- Rich Presence text options
     editing_text        = "Editing %s",               -- Format string rendered when an editable file is loaded in the buffer
@@ -46,6 +47,7 @@ require("presence"):setup({
     plugin_manager_text = "Managing plugins"          -- Format string rendered when managing plugins
     reading_text        = "Reading %s"                -- Format string rendered when a read-only or unmodifiable file is loaded in the buffer
     workspace_text      = "Working on %s",            -- Workspace format string (either string or function(git_project_name: string|nil, buffer: string): string)
+	line_number_text    = "Line %s out of %s",        -- Line number format string (for when enable_line_number is set to true)
 })
 ```
 
@@ -58,7 +60,8 @@ let g:presence_neovim_image_text   = "The One True Text Editor"
 let g:presence_main_image          = "neovim"
 let g:presence_client_id           = "793271441293967371"
 let g:presence_log_level
-let g:presence_debounce_timeout    = 15
+let g:presence_debounce_timeout    = 10
+let g:presence_enable_line_number  = false
 
 " Rich Presence text options
 let g:presence_editing_text        = "Editing %s"
@@ -67,6 +70,7 @@ let g:presence_git_commit_text     = "Committing changes"
 let g:presence_plugin_manager_text = "Managing plugins"
 let g:presence_reading_text        = "Reading %s"
 let g:presence_workspace_text      = "Working on %s"
+let g:presence_line_number_text    = "Line %s out of %s"
 ```
 
 ## Troubleshooting

--- a/autoload/presence.vim
+++ b/autoload/presence.vim
@@ -4,7 +4,7 @@ function presence#SetAutoCmds()
         autocmd!
         if exists("g:presence_auto_update") && g:presence_auto_update
             autocmd BufEnter * lua package.loaded.presence:update()
-            autocmd InsertEnter * lua package.loaded.presence:update(nil, true)
+            autocmd TextChanged * lua package.loaded.presence:update(nil, true)
             autocmd VimLeavePre * lua package.loaded.presence:unregister_self()
         endif
     augroup END

--- a/autoload/presence.vim
+++ b/autoload/presence.vim
@@ -3,7 +3,7 @@ function presence#SetAutoCmds()
     augroup presence_events
         autocmd!
         if exists("g:presence_auto_update") && g:presence_auto_update
-            autocmd BufRead * lua package.loaded.presence:update()
+            autocmd BufEnter * lua package.loaded.presence:update()
             autocmd InsertEnter * lua package.loaded.presence:update(nil, true)
             autocmd VimLeavePre * lua package.loaded.presence:unregister_self()
         endif

--- a/autoload/presence.vim
+++ b/autoload/presence.vim
@@ -4,7 +4,7 @@ function presence#SetAutoCmds()
         autocmd!
         if exists("g:presence_auto_update") && g:presence_auto_update
             autocmd BufRead * lua package.loaded.presence:update()
-            autocmd TextChanged * lua package.loaded.presence:update(nil, true)
+            autocmd InsertEnter * lua package.loaded.presence:update(nil, true)
             autocmd VimLeavePre * lua package.loaded.presence:unregister_self()
         endif
     augroup END

--- a/lua/presence/init.lua
+++ b/lua/presence/init.lua
@@ -549,8 +549,8 @@ function Presence:update_for_buffer(buffer, should_debounce)
         local line_number_text = self.options.line_number_text
 
         activity.details = type(line_number_text) == "function"
-	    and line_number_text(line_number, line_count)
-	    or string.format(line_number_text, line_number, line_count)
+        and line_number_text(line_number, line_count)
+        or string.format(line_number_text, line_number, line_count)
 
         self.workspace = nil
         self.last_activity = {

--- a/lua/presence/init.lua
+++ b/lua/presence/init.lua
@@ -526,64 +526,64 @@ function Presence:update_for_buffer(buffer, should_debounce)
             workspace = nil,
         }
     else
-		-- Include project details if available and if the user hasn't set the enable_line_number option
+        -- Include project details if available and if the user hasn't set the enable_line_number option
 
         self.log:debug(string.format("Getting project name for %s...", parent_dirpath))
 
-		local workspace_text = self.options.workspace_text
-		local project_name, project_path = self:get_project_name(parent_dirpath)
+        local workspace_text = self.options.workspace_text
+        local project_name, project_path = self:get_project_name(parent_dirpath)
 
-		if project_name then
+        if project_name then
 
-			self.log:debug(string.format("Detected project: %s", project_name))
+            self.log:debug(string.format("Detected project: %s", project_name))
 
-			activity.details = type(workspace_text) == "function"
-				and workspace_text(project_name, buffer)
-				or string.format(workspace_text, project_name)
+            activity.details = type(workspace_text) == "function"
+                and workspace_text(project_name, buffer)
+                or string.format(workspace_text, project_name)
 
-			self.workspace = project_path
-			self.last_activity = {
-				file = buffer,
-				set_at = activity_set_at,
-				relative_set_at = relative_activity_set_at,
-				workspace = project_path,
-			}
+            self.workspace = project_path
+            self.last_activity = {
+                file = buffer,
+                set_at = activity_set_at,
+                relative_set_at = relative_activity_set_at,
+                workspace = project_path,
+            }
 
-			if self.workspaces[project_path] then
-				self.workspaces[project_path].updated_at = activity_set_at
-				activity.timestamps = {
-					start = self.workspaces[project_path].started_at,
-				}
-			else
-				self.workspaces[project_path] = {
-					started_at = activity_set_at,
-					updated_at = activity_set_at,
-				}
-			end
+            if self.workspaces[project_path] then
+                self.workspaces[project_path].updated_at = activity_set_at
+                activity.timestamps = {
+                    start = self.workspaces[project_path].started_at,
+                }
+            else
+                self.workspaces[project_path] = {
+                    started_at = activity_set_at,
+                    updated_at = activity_set_at,
+                }
+            end
 
-		else
-			self.log:debug("No project detected")
+        else
+            self.log:debug("No project detected")
 
-			self.workspace = nil
-			self.last_activity = {
-				file = buffer,
-				set_at = activity_set_at,
-				relative_set_at = relative_activity_set_at,
-				workspace = nil,
-			}
+            self.workspace = nil
+            self.last_activity = {
+                file = buffer,
+                set_at = activity_set_at,
+                relative_set_at = relative_activity_set_at,
+                workspace = nil,
+            }
 
-			-- When no project is detected, set custom workspace text if:
-			-- * The custom function returns custom workspace text
-			-- * The configured workspace text does not contain a directive
-			if type(workspace_text) == "function" then
-				local custom_workspace_text = workspace_text(nil, buffer)
-				if custom_workspace_text then
-					activity.details = custom_workspace_text
-				end
-			elseif not workspace_text:find("%s") then
-				activity.details = workspace_text
-			end
-		end
+            -- When no project is detected, set custom workspace text if:
+            -- * The custom function returns custom workspace text
+            -- * The configured workspace text does not contain a directive
+            if type(workspace_text) == "function" then
+                local custom_workspace_text = workspace_text(nil, buffer)
+                if custom_workspace_text then
+                    activity.details = custom_workspace_text
+                end
+            elseif not workspace_text:find("%s") then
+                activity.details = workspace_text
+            end
+        end
     end
 
     -- Sync activity to all peers

--- a/lua/presence/init.lua
+++ b/lua/presence/init.lua
@@ -463,7 +463,8 @@ end
 function Presence:update_for_buffer(buffer, should_debounce)
 
     local activity_set_at = os.time()
-    -- If we shouldn't debounce and we trigger an activity, keep this value the same. Otherwise set it to the current time.
+    -- If we shouldn't debounce and we trigger an activity, keep this value the same.
+    -- Otherwise set it to the current time.
     local relative_activity_set_at = should_debounce and self.last_activity.relative_set_at or os.time()
 
     self.log:debug(string.format("Setting activity for %s...", buffer))
@@ -507,7 +508,7 @@ function Presence:update_for_buffer(buffer, should_debounce)
     }
 
     -- Get the current line number and line count if the user has set the enable_line_number option
-    if self.options.enable_line_number then
+    if self.options.enable_line_number == 1 then
         self.log:debug("Getting line number for current buffer...")
 
         local line_number = vim.api.nvim_win_get_cursor(0)[1]

--- a/lua/presence/init.lua
+++ b/lua/presence/init.lua
@@ -506,43 +506,9 @@ function Presence:update_for_buffer(buffer, should_debounce)
         },
     }
 
-    if not self.options.enable_line_number then
+    -- Get the current line number and line count if the user has set the enable_line_number option
+    if self.options.enable_line_number then
         self.log:debug("Getting line number for current buffer...")
-    else
-        self.log:debug(string.format("Getting project name for %s...", parent_dirpath))
-    end
-
-    local workspace_text = self.options.workspace_text
-    local project_name, project_path = self:get_project_name(parent_dirpath)
-
-    -- Include project details if available and if the user hasn't set the enable_line_number option
-    if project_name and self.options.enable_line_number == 0 then
-        self.log:debug(string.format("Detected project: %s", project_name))
-
-        activity.details = type(workspace_text) == "function"
-            and workspace_text(project_name, buffer)
-            or string.format(workspace_text, project_name)
-
-        self.workspace = project_path
-        self.last_activity = {
-            file = buffer,
-            set_at = activity_set_at,
-            relative_set_at = relative_activity_set_at,
-            workspace = project_path,
-        }
-
-        if self.workspaces[project_path] then
-            self.workspaces[project_path].updated_at = activity_set_at
-            activity.timestamps = {
-                start = self.workspaces[project_path].started_at,
-            }
-        else
-            self.workspaces[project_path] = {
-                started_at = activity_set_at,
-                updated_at = activity_set_at,
-            }
-        end
-    elseif self.options.enable_line_number == 1 then
 
         local line_number = vim.api.nvim_win_get_cursor(0)[1]
         local line_count = vim.api.nvim_buf_line_count(0)
@@ -559,29 +525,65 @@ function Presence:update_for_buffer(buffer, should_debounce)
             relative_set_at = relative_activity_set_at,
             workspace = nil,
         }
-
     else
-        self.log:debug("No project detected")
+		-- Include project details if available and if the user hasn't set the enable_line_number option
 
-        self.workspace = nil
-        self.last_activity = {
-            file = buffer,
-            set_at = activity_set_at,
-            relative_set_at = relative_activity_set_at,
-            workspace = nil,
-        }
+        self.log:debug(string.format("Getting project name for %s...", parent_dirpath))
 
-        -- When no project is detected, set custom workspace text if:
-        -- * The custom function returns custom workspace text
-        -- * The configured workspace text does not contain a directive
-        if type(workspace_text) == "function" then
-            local custom_workspace_text = workspace_text(nil, buffer)
-            if custom_workspace_text then
-                activity.details = custom_workspace_text
-            end
-        elseif not workspace_text:find("%s") then
-            activity.details = workspace_text
-        end
+		local workspace_text = self.options.workspace_text
+		local project_name, project_path = self:get_project_name(parent_dirpath)
+
+		if project_name then
+
+			self.log:debug(string.format("Detected project: %s", project_name))
+
+			activity.details = type(workspace_text) == "function"
+				and workspace_text(project_name, buffer)
+				or string.format(workspace_text, project_name)
+
+			self.workspace = project_path
+			self.last_activity = {
+				file = buffer,
+				set_at = activity_set_at,
+				relative_set_at = relative_activity_set_at,
+				workspace = project_path,
+			}
+
+			if self.workspaces[project_path] then
+				self.workspaces[project_path].updated_at = activity_set_at
+				activity.timestamps = {
+					start = self.workspaces[project_path].started_at,
+				}
+			else
+				self.workspaces[project_path] = {
+					started_at = activity_set_at,
+					updated_at = activity_set_at,
+				}
+			end
+
+		else
+			self.log:debug("No project detected")
+
+			self.workspace = nil
+			self.last_activity = {
+				file = buffer,
+				set_at = activity_set_at,
+				relative_set_at = relative_activity_set_at,
+				workspace = nil,
+			}
+
+			-- When no project is detected, set custom workspace text if:
+			-- * The custom function returns custom workspace text
+			-- * The configured workspace text does not contain a directive
+			if type(workspace_text) == "function" then
+				local custom_workspace_text = workspace_text(nil, buffer)
+				if custom_workspace_text then
+					activity.details = custom_workspace_text
+				end
+			elseif not workspace_text:find("%s") then
+				activity.details = workspace_text
+			end
+		end
     end
 
     -- Sync activity to all peers


### PR DESCRIPTION
This PR has been laying around on my disk for a long time now, hence why it can't automatically merge it :P

It adds the ability to enable line numbers to be shown in the presence window rather than the current working project. The line number updates whenever `debounce_timeout` has passed and whenever the user enters insert mode. It's lightweight and the user doesn't feel any lag when editing. I got the inspiration for this from the emacs rich presence.