### PR TITLE
Add support for Racket (.rkt)

### DIFF
--- a/lua/presence/file_assets.lua
+++ b/lua/presence/file_assets.lua
@@ -229,6 +229,7 @@ return {
     rb = { "Ruby", "ruby" },
     re = { "Reason", "reason" },
     res = { "ReScript", "rescript" },
+    rkt = { "Racket", "racket"},
     rs = { "Rust", "rust" },
     sass = { "Sass", "sass" },
     scala = { "Scala", "scala" },


### PR DESCRIPTION
Add support for .rkt files.

1024x1024 logo from [Wikipedia](https://wikipedia.org/wiki/File:Racket-logo.svg):

![Racket Logo](https://wikiless.org/media/wikipedia/commons/thumb/c/c1/Racket-logo.svg/1024px-Racket-logo.svg.png)