### PR TITLE
Fix Microsoft kernel detection for WSL 2

### DIFF
--- a/lua/presence/init.lua
+++ b/lua/presence/init.lua
@@ -84,7 +84,7 @@ function Presence:setup(options)
     local os_name = self.get_os_name(uname)
     self.os = {
         name = os_name,
-        is_wsl = uname.release:find("Microsoft") ~= nil,
+        is_wsl = uname.release:lower():find("microsoft") ~= nil,
         path_separator = separator,
     }
 


### PR DESCRIPTION
The kernel version on WSL 2 contains "microsoft" instead of "Microsoft" like in WSL 1.

WSL 1:
```
bas@bamibal:~$ uname -r
4.4.0-22572-Microsoft
```
WSL 2:
```
bas@bamibal:~$ uname -r
5.10.102.1-microsoft-standard-WSL2
```

Could also change the check to `vim.fn.has('wsl') == 1` instead, which already does the same case-insensitive match internally: https://github.com/neovim/neovim/blob/be35d3c5ad501abb029279f8e1812d0e4525284f/src/nvim/eval/funcs.c#L4491-L4492

Up to you really