### PR TITLE
Fix sudo error on macOS

### DIFF
--- a/lua/presence/init.lua
+++ b/lua/presence/init.lua
@@ -365,9 +365,12 @@ function Presence:get_discord_socket_path()
     elseif self.os.name == "macos" then
         -- Use $TMPDIR for macOS
         local path = os.getenv("TMPDIR")
-        sock_path = path:match("/$")
-            and path..sock_name
-            or path.."/"..sock_name
+
+        if path then
+            sock_path = path:match("/$")
+                and path..sock_name
+                or path.."/"..sock_name
+        end
     elseif self.os.name == "linux" then
         -- Check various temp directory environment variables
         local env_vars = {


### PR DESCRIPTION
When using sudo a separate environment is used unless specifying sudo -E. This fixes the error of path being nil when using neovim in sudo