### PR TITLE
Add ability to disable the timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ require("presence"):setup({
     blacklist           = {},                         -- A list of strings or Lua patterns that disable Rich Presence if the current file name, path, or workspace matches
     buttons             = true,                       -- Configure Rich Presence button(s), either a boolean to enable/disable, a static table (`{{ label = "<label>", url = "<url>" }, ...}`, or a function(buffer: string, repo_url: string|nil): table)
     file_assets         = {},                         -- Custom file asset definitions keyed by file names and extensions (see default config at `lua/presence/file_assets.lua` for reference)
+    show_time           = true,                       -- Show the timer
 
     -- Rich Presence text options
     editing_text        = "Editing %s",               -- Format string rendered when an editable file is loaded in the buffer (either string or function(filename: string): string)
@@ -70,6 +71,7 @@ let g:presence_enable_line_number  = 0
 let g:presence_blacklist           = []
 let g:presence_buttons             = 1
 let g:presence_file_assets         = {}
+let g:presence_show_time           = 1
 
 " Rich Presence text options
 let g:presence_editing_text        = "Editing %s"

--- a/lua/presence/init.lua
+++ b/lua/presence/init.lua
@@ -121,6 +121,7 @@ function Presence:setup(options)
     self:set_option("line_number_text", "Line %s out of %s")
     self:set_option("blacklist", {})
     self:set_option("buttons", true)
+    self:set_option("show_time", true)
     -- File assets options
     self:set_option("file_assets", {})
     for name, asset in pairs(default_file_assets) do
@@ -820,9 +821,9 @@ function Presence:update_for_buffer(buffer, should_debounce)
     local activity = {
         state = status_text,
         assets = assets,
-        timestamps = {
+        timestamps = self.options.show_time == 1 and {
             start = relative_activity_set_at,
-        },
+        } or nil,
     }
 
     -- Add button that links to the git workspace remote origin url
@@ -870,9 +871,9 @@ function Presence:update_for_buffer(buffer, should_debounce)
 
             if self.workspaces[project_path] then
                 self.workspaces[project_path].updated_at = activity_set_at
-                activity.timestamps = {
+                activity.timestamps = self.options.show_time == 1 and {
                     start = self.workspaces[project_path].started_at,
-                }
+                } or nil
             else
                 self.workspaces[project_path] = {
                     started_at = activity_set_at,


### PR DESCRIPTION
This adds `show_time` to the config, which will turn the timer off. The default is true.

`let g:presence_show_time = 0`
or
```lua
require("presence"):setup({
    show_time = false
})
```

![CleanShot 2022-08-14 at 18 36 31](https://user-images.githubusercontent.com/16886888/184557379-93c3a5cd-08f2-4ecf-a73f-fa95d31de61e.png)