### PR TITLE
Fix wrong buffer path when using netrw on windows (#83)

### DIFF
--- a/lua/presence/init.lua
+++ b/lua/presence/init.lua
@@ -758,6 +758,12 @@ end
 
 -- Update Rich Presence for the provided vim buffer
 function Presence:update_for_buffer(buffer, should_debounce)
+
+    -- Since git always uses forward slashes, replace with backslash in Windows
+    if self.os.name == "windows" then
+        buffer = buffer:gsub("/", [[\]])
+    end
+
     -- Avoid unnecessary updates if the previous activity was for the current buffer
     -- (allow same-buffer updates when line numbers are enabled)
     if self.options.enable_line_number == 0 and self.last_activity.file == buffer then


### PR DESCRIPTION
As described in #83, when opening a file using netrw, the wrong path separator gets used on windows.
This PR fixes that.

I'm not sure if it's worth it introducing an extra function for that small check.
I'm not that fluent in lua and I tried to do it, but i had some weird errors.
