### PR TITLE
Fix time kept when no workspace or line numbers on

### DIFF
--- a/lua/presence/init.lua
+++ b/lua/presence/init.lua
@@ -791,9 +791,8 @@ function Presence:update_for_buffer(buffer, should_debounce)
     end
 
     local activity_set_at = os.time()
-    -- If we shouldn't debounce and we trigger an activity, keep this value the same.
-    -- Otherwise set it to the current time.
-    local relative_activity_set_at = should_debounce and self.last_activity.relative_set_at or os.time()
+    -- Set the relative time if it does not already exist
+    local relative_activity_set_at = self.last_activity.relative_set_at or os.time()
 
     self.log:debug(string.format("Setting activity for %s...", buffer and #buffer > 0 and buffer or "unnamed buffer"))
 


### PR DESCRIPTION
#49 states that time elapsed is not kept across events while working on non workspace projects, this is also the case for when line numbers are enabled. Simply changing the relative_activity_set_at variable to be persistent fixes both of these issues, and I could not find any reason for this variable to change either way.