### PR TITLE
Add lazy.nvim install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 Use your favorite plugin manager
 * [vim-plug](https://github.com/junegunn/vim-plug): `Plug 'andweeb/presence.nvim'`
 * [packer.nvim](https://github.com/wbthomason/packer.nvim): `use 'andweeb/presence.nvim'`
+* [lazy.nvim](https://github.com/folke/lazy.nvim): `{ "andweeb/presence.nvim", lazy = false },`
 
 #### Notes
 * Requires [Neovim 0.5](https://github.com/neovim/neovim/releases/tag/v0.5.0) or higher


### PR DESCRIPTION
Just adding [Lazy.nvim](https://github.com/folke/lazy.nvim) install instructions.  
I used `lazy = false` to disable lazy-loading because it makes sense to always start this plugin and have rich presence started.