### PR TITLE
add ability to put custom main image

### DIFF
--- a/lua/presence/init.lua
+++ b/lua/presence/init.lua
@@ -823,7 +823,8 @@ function Presence:update_for_buffer(buffer, should_debounce)
     local use_file_as_main_image = self.options.main_image == "file"
     local use_neovim_as_main_image = self.options.main_image == "neovim"
     local assets = {
-        large_image = use_file_as_main_image and asset_key or use_neovim_as_main_image and  "neovim" or self.options.main_image,
+        large_image = use_file_as_main_image and asset_key or use_neovim_as_main_image
+                      and "neovim" or self.options.main_image,
         large_text = use_file_as_main_image and file_text or neovim_image_text,
         small_image = use_file_as_main_image and "neovim" or asset_key,
         small_text = use_file_as_main_image and neovim_image_text or file_text,

--- a/lua/presence/init.lua
+++ b/lua/presence/init.lua
@@ -119,6 +119,7 @@ function Presence:setup(...)
     self:set_option("client_id", "793271441293967371")
     self:set_option("debounce_timeout", 10)
     self:set_option("neovim_image_text", "The One True Text Editor")
+    self:set_option("main_image", "neovim")
     self:set_option("enable_line_number", false)
     -- Status text options
     self:set_option("editing_text", "Editing %s")

--- a/lua/presence/init.lua
+++ b/lua/presence/init.lua
@@ -118,7 +118,6 @@ function Presence:setup(...)
     self:set_option("auto_update", 1)
     self:set_option("client_id", "793271441293967371")
     self:set_option("debounce_timeout", 10)
-    self:set_option("main_image", "neovim")
     self:set_option("neovim_image_text", "The One True Text Editor")
     self:set_option("enable_line_number", false)
     -- Status text options
@@ -821,8 +820,9 @@ function Presence:update_for_buffer(buffer, should_debounce)
     local file_text = description or name
     local neovim_image_text = self.options.neovim_image_text
     local use_file_as_main_image = self.options.main_image == "file"
+    local use_neovim_as_main_image = self.options.main_image == "neovim"
     local assets = {
-        large_image = use_file_as_main_image and asset_key or "neovim",
+        large_image = use_file_as_main_image and asset_key or use_neovim_as_main_image and  "neovim" or self.options.main_image,
         large_text = use_file_as_main_image and file_text or neovim_image_text,
         small_image = use_file_as_main_image and "neovim" or asset_key,
         small_text = use_file_as_main_image and neovim_image_text or file_text,


### PR DESCRIPTION
#102  
i edit `init.lua` to allow users change main image in setup 
```
require("presence").setup({
 .... 
    main_image          = "neovim",                   -- Main image display (either "neovim" or "file")
....})
``` 
now it will be `neovim or file or image-url`

Example: 
```
    main_image    = "https://ih1.redbubble.net/image.4300886209.2465/st,small,845x845-pad,1000x1000,f8f8f8.jpg"
```


![image](https://github.com/andweeb/presence.nvim/assets/88988252/22cc2e4f-f2f3-45d3-87f4-61ac09ad94d6)
@andweeb 