### PR TITLE
Update line number when cursor moves

### DIFF
--- a/autoload/presence.vim
+++ b/autoload/presence.vim
@@ -10,6 +10,8 @@ function presence#SetAutoCmds()
             autocmd WinLeave * lua package.loaded.presence:handle_win_leave()
             autocmd BufEnter * lua package.loaded.presence:handle_buf_enter()
             autocmd BufAdd * lua package.loaded.presence:handle_buf_add()
+            autocmd CursorMoved * lua package.loaded.presence:handle_cursor_moved()
+            autocmd CursorMovedI * lua package.loaded.presence:handle_cursor_moved()
         endif
     augroup END
 endfunction

--- a/lua/presence/init.lua
+++ b/lua/presence/init.lua
@@ -1246,4 +1246,13 @@ function Presence:handle_buf_add()
     end)
 end
 
+-- CursorMoved and CursorMovedI events update the line number
+function Presence:handle_cursor_moved()
+    self.log:debug("Handling CursorMoved/CursorMovedI event...")
+
+    if self.options.enable_line_number == 1 then
+        self:update(nil, true)
+    end
+end
+
 return Presence

--- a/lua/presence/init.lua
+++ b/lua/presence/init.lua
@@ -945,7 +945,7 @@ Presence.update = Presence.discord_event(function(self, buffer, should_debounce)
     local should_skip =
         should_debounce and
         debounce_timeout and
-        last_updated_at and os.time() - last_updated_at <= debounce_timeout
+        last_updated_at and os.time() - last_updated_at < debounce_timeout
 
     if should_skip then
         local message_fmt = "Last activity sent was within %d seconds ago, skipping..."


### PR DESCRIPTION
Add an event handler so that the line number gets updated when you move the cursor.
Previous behavior was unless you switch buffers or switch the focus or something like that, the line number doesnt get updated at all 