### PR TITLE
fixed bug that crashes the plugin on load

### DIFF
--- a/lua/presence/init.lua
+++ b/lua/presence/init.lua
@@ -355,7 +355,7 @@ function Presence:authorize(on_done)
             return
         end
 
-        self.log:info(string.format("Authorized with Discord for %s", response.data.user.username))
+        --self.log:info(string.format("Authorized with Discord for %s", response.data.user.username))
         self.is_authorized = true
 
         if on_done then on_done() end


### PR DESCRIPTION
commented out the line that logs the user's username, see https://github.com/andweeb/presence.nvim/issues/139#issuecomment-1823587392

I think this broke because of the new-ish username system and this variable might not exist anymore?
whatever, it's hacky, but it works.